### PR TITLE
Centralize theme colors

### DIFF
--- a/colors.css
+++ b/colors.css
@@ -1,0 +1,11 @@
+:root {
+  --primary-color: #2c3d4f;
+  --secondary-color: #3e7ab7;
+  --accent-color: #ffbb00;
+  --background-color: #f7f7f7;
+  --text-color: #333333;
+  --muted-color: #e0e0e0;
+  --border-color: #cccccc;
+  --light-color: #ffffff;
+  --dark-text-color: #343434;
+}

--- a/login/login.css
+++ b/login/login.css
@@ -1,16 +1,9 @@
-:root {
-  --primary-yellow: #ffc107;
-  --primary-blue: #2776ba;
-  --dark-gray: #373737;
-  --light-gray: #f5f5f5;
-  --white: #fff;
-  --shadow: 0 8px 40px 0 rgba(55, 55, 55, 0.16);
-}
+@import url("../colors.css");
 
 body {
   margin: 0;
   padding: 0;
-  background: #e2e2e2;
+  background: var(--muted-color);
   font-family: "Open Sans", sans-serif;
   min-height: 100vh;
   display: flex;
@@ -33,7 +26,7 @@ body {
   transform: translateY(-50%);
   width: 340px;
   min-height: 350px;
-  background: #ffffff;
+  background: var(--light-color);
   border-radius: 5px;
   z-index: 2;
   box-shadow: var(--shadow);
@@ -53,8 +46,8 @@ body {
 .btn-whatsapp {
   display: inline-flex;
   align-items: center;
-  background: #25d366;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   font-weight: bold;
   border-radius: 8px;
   padding: 5px 12px;
@@ -64,14 +57,14 @@ body {
 }
 
 .btn-whatsapp:hover {
-  background-color: #1aa84e;
+  background-color: var(--secondary-color);
 }
 
 .btn-zendesk {
   display: inline-flex;
   align-items: center;
-  background: #fec107;
-  color: black;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: bold;
   border-radius: 8px;
   padding: 5px 12px;
@@ -82,13 +75,13 @@ body {
   transition: background 0.2s;
 }
 .btn-zendesk:hover {
-  background: #ffd146;
+  background: var(--accent-color);
 }
 
 .btn-saml {
   width: 100%;
-  background: #fec107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: 700;
   border: none;
   padding: 12px 0;
@@ -97,7 +90,7 @@ body {
   cursor: pointer;
   margin-bottom: 20px;
   transition: background 0.2s;
-  box-shadow: 0 2px 10px 0 #0001;
+  box-shadow: 0 2px 10px 0 rgba(0,0,0,0.06);
   letter-spacing: 0.5px;
   display: flex;
   align-items: center;
@@ -107,11 +100,11 @@ body {
 
 .btn-saml a {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .btn-saml:hover {
-  background: #e5b200;
+  background: var(--accent-color);
 }
 
 .divisor {
@@ -119,7 +112,7 @@ body {
   text-align: center;
   margin: 12px 0 18px 0;
   position: relative;
-  color: #535353;
+  color: var(--text-color);
   font-size: 15.68px;
 }
 
@@ -129,7 +122,7 @@ body {
   display: inline-block;
   width: 40%;
   height: 1px;
-  background: #535353;
+  background: var(--text-color);
   position: relative;
   vertical-align: middle;
   margin: 0 8px;
@@ -137,7 +130,7 @@ body {
 
 .login-form h2 {
   margin: 0 0 18px 0;
-  color: #373737;
+  color: var(--dark-text-color);
   font-weight: 700;
   font-size: 19.52px;
   letter-spacing: 1px;
@@ -147,7 +140,7 @@ body {
 .input-group {
   display: flex;
   align-items: center;
-  background: #f5f5f5;
+  background: var(--background-color);
   border: 2px solid transparent;
   border-radius: 9px;
   margin-bottom: 20px;
@@ -155,7 +148,7 @@ body {
 }
 
 .input-group svg {
-  color: #2776ba;
+  color: var(--secondary-color);
   margin-right: 8px;
   font-size: 19.2px;
 }
@@ -167,11 +160,11 @@ body {
   padding: 13px 8px;
   width: 100%;
   font-size: 13.6px;
-  color: #373737;
+  color: var(--dark-text-color);
 }
 .input-group:focus-within {
-  border: 2px solid #2776ba;
-  background: #e6f2fb;
+  border: 2px solid var(--secondary-color);
+  background: var(--background-color);
 }
 
 .esqueceu-senha {
@@ -179,20 +172,20 @@ body {
   align-items: center;
   justify-content: space-between;
   font-size: 15.2px;
-  color: #373737;
+  color: var(--dark-text-color);
   margin-bottom: 18px;
 }
 
 .esqueceu-senha a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
   font-size: 13.6px;
 }
 
 .btn-login {
-  background: #2776ba;
-  color: white;
+  background: var(--secondary-color);
+  color: var(--light-color);
   font-weight: 700;
   border: none;
   padding: 12px 0;
@@ -210,11 +203,11 @@ body {
 
 .btn-login a {
   text-decoration: none;
-  color: white;
+  color: var(--light-color);
 }
 
 .btn-login:hover {
-  background: #185380;
+  background: var(--primary-color);
 }
 
 .welcome-panel {
@@ -223,14 +216,14 @@ body {
   top: 0;
   width: 480px;
   height: 440px;
-  background: #2c3d4f;
+  background: var(--primary-color);
   border-radius: 5px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 1;
-  color: white;
+  color: var(--light-color);
   box-shadow: var(--shadow);
   overflow: hidden;
 }
@@ -240,8 +233,8 @@ body {
   font-weight: 900;
   margin-bottom: 18px;
   margin-left: 40px;
-  color: #ffc107;
-  text-shadow: 1px 2px 8px #0033663c;
+  color: var(--accent-color);
+  text-shadow: 1px 2px 8px rgba(44,61,79,0.24);
   letter-spacing: 1.3px;
 }
 
@@ -255,12 +248,12 @@ body {
 }
 
 .welcome-panel span {
-  color: #ffc107;
+  color: var(--accent-color);
 }
 
 .btn-know {
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: bold;
   border: none;
   padding: 12px 42px;
@@ -270,16 +263,16 @@ body {
   cursor: pointer;
   margin-top: 12px;
   transition: background 0.2s;
-  box-shadow: 0 2px 8px 0 #2223;
+  box-shadow: 0 2px 8px 0 rgba(0,0,0,0.2);
 }
 
 .btn-know a {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .btn-know:hover {
-  background: #e5b200;
+  background: var(--accent-color);
 }
 
 @media (max-width: 940px) {
@@ -346,10 +339,10 @@ body {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
-  box-shadow: 0 4px 20px #0002;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.13);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -360,8 +353,8 @@ body {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #d6a100;
-  box-shadow: 0 6px 32px #0003;
+  background: var(--accent-color);
+  box-shadow: 0 6px 32px rgba(0,0,0,0.2);
 }
 
 .chat-popup {
@@ -371,17 +364,17 @@ body {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
-  box-shadow: 0 6px 32px #0003;
+  box-shadow: 0 6px 32px rgba(0,0,0,0.2);
   z-index: 2500;
   overflow: hidden;
   font-family: "Open Sans", "Roboto", Arial, sans-serif;
 }
 
 .chat-header {
-  background: #2c3d4f;
-  color: #fff;
+  background: var(--primary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -393,7 +386,7 @@ body {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -408,7 +401,7 @@ body {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
@@ -423,7 +416,7 @@ body {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/modulos/style.css
+++ b/modulos/style.css
@@ -1,16 +1,9 @@
-:root {
-  --azul: #2776ba;
-  --amarelo: #ffc107;
-  --cinza-claro: #f5f5f5;
-  --cinza-fundo: #e2e2e2;
-  --cinza-escuro: #2c3d4f;
-  --branco: #fff;
-}
+@import url("../colors.css");
 
 body {
   margin: 0;
   font-family: "Open Sans", sans-serif;
-  background: var(--cinza-fundo);
+  background: var(--muted-color);
 }
 
 .pagina-selecao {
@@ -25,8 +18,8 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 8px 16px;
-  background: var(--cinza-escuro);
-  border-bottom: 2px solid #555;
+  background: var(--primary-color);
+  border-bottom: 2px solid var(--text-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
@@ -39,12 +32,12 @@ body {
   align-items: center;
   gap: 12px;
   font-weight: 600;
-  color: white;
+  color: var(--light-color);
 }
 
 .avatar {
-  background: var(--cinza-fundo);
-  color: black;
+  background: var(--muted-color);
+  color: var(--dark-text-color);
   width: 28px;
   height: 28px;
   border-radius: 50%;
@@ -79,7 +72,7 @@ body {
 .titulo-principal {
   font-size: 3.2rem;
   font-weight: 800;
-  color: #111;
+  color: var(--dark-text-color);
   position: relative;
   z-index: 1;
   margin: 0;
@@ -93,14 +86,14 @@ body {
   bottom: 1px;
   width: 100%;
   height: 4px;
-  background: var(--amarelo);
+  background: var(--accent-color);
   border-radius: 10px;
   z-index: 0;
 }
 
 /* Grade de módulos */
 .container-modulos {
-  background: #eeeeee;
+  background: var(--background-color);
   padding: 32px 28px;
   border-radius: 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
@@ -108,7 +101,7 @@ body {
   max-width: 900px;
   max-height: 440px;
   overflow-y: auto;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 
 .lista-modulos {
@@ -121,9 +114,9 @@ body {
   padding: 12px 18px;
   font-size: 1rem;
   font-weight: bold;
-  color: var(--cinza-escuro);
-  background-color: #e0e0e0;
-  border-bottom: 1px solid #eee;
+  color: var(--primary-color);
+  background-color: var(--muted-color);
+  border-bottom: 1px solid var(--background-color);
   transition: background 0.2s ease, padding-left 0.2s ease;
   cursor: pointer;
   border-radius: 6px;
@@ -132,16 +125,16 @@ body {
 
 .lista-modulos a {
   text-decoration: none;
-  color: var(--cinza-escuro);
+  color: var(--primary-color);
 }
 
 .lista-modulos li:nth-child(even) {
-  background-color: var(--cinza-claro);
+  background-color: var(--background-color);
 }
 
 .lista-modulos li:hover {
-  background-color: var(--amarelo);
-  color: #000;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   padding-left: 28px;
 }
 
@@ -150,12 +143,12 @@ body {
 }
 
 .container-modulos::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--background-color);
   border-radius: 10px;
 }
 
 .container-modulos::-webkit-scrollbar-thumb {
-  background-color: var(--amarelo);
+  background-color: var(--accent-color);
   border-radius: 10px;
   border: 2px solid transparent;
   background-clip: content-box;


### PR DESCRIPTION
## Summary
- Introduce `colors.css` with a shared set of theme variables
- Refactor module selection and login styles to import the palette and use variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a29c1ed5c8330a90e558932863d2b