### PR TITLE
Centralize theme colors

### DIFF
--- a/capaprocesso/capa-de-processo.css
+++ b/capaprocesso/capa-de-processo.css
@@ -1,3 +1,5 @@
+@import url("../colors.css");
+
 /* ---------- RESET E BASE ---------- */
 * {
   box-sizing: border-box;
@@ -5,15 +7,15 @@
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -34,7 +36,7 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -97,12 +99,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -183,7 +185,7 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .imp-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -254,7 +256,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 8px;
-  background: #fff;
+  background: var(--light-color);
   padding: 16px 16px 10px 16px;
   border-radius: 12px;
   box-shadow: 0 1px 6px rgba(70, 90, 110, 0.07);
@@ -262,7 +264,7 @@ nav {
 }
 
 .card-grafico {
-  background: #ffffff;
+  background: var(--light-color);
   border-radius: 12px;
   padding-top: 40px;
   padding-bottom: 40px;
@@ -279,7 +281,7 @@ nav {
 
 .sair {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .fitros-consulta {
@@ -298,10 +300,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 4px 6px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 15px;
-  background-color: white;
+  background-color: var(--light-color);
   margin-bottom: 20px;
 }
 
@@ -357,7 +359,7 @@ nav {
   font-size: 14px;
   margin: 0 0 2px 0;
   padding: 0;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 
 .grupo-associar {
@@ -371,11 +373,11 @@ nav {
 
 .associar-responsavel select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   width: 385px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
   min-width: 140px;
   margin: 0;
 }
@@ -383,7 +385,7 @@ nav {
 .associar-botao {
   padding: 8px 18px;
   background-color: #c9c9c9;
-  color: black;
+  color: var(--dark-text-color);
   border: none;
   border-radius: 5px;
   cursor: pointer;
@@ -423,7 +425,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -449,7 +451,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -489,7 +491,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -497,8 +499,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -510,7 +512,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -559,7 +561,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -579,7 +581,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -597,7 +599,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -608,7 +610,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -643,7 +645,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -674,7 +676,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -686,8 +688,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   margin-bottom: 30px;
@@ -698,7 +700,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -711,31 +713,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -856,7 +858,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
 }
 
@@ -888,8 +890,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -899,12 +901,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -924,18 +926,18 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -958,17 +960,17 @@ body.dark-mode .imp-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode th {
   background-color: #3d3d3d;
@@ -994,22 +996,22 @@ body.dark-mode .slider::before {
   box-shadow: inset 8px -3px 0px 0px var(--dark);
 }
 body.dark-mode .associacao button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associacao button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1027,33 +1029,33 @@ body.dark-mode .container {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .painel-geral {
@@ -1064,23 +1066,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1090,8 +1092,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1104,7 +1106,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1115,7 +1117,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1124,8 +1126,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1137,7 +1139,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1152,12 +1154,12 @@ body.dark-mode .fitros-consulta input::placeholder {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
 .chat-body a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: underline;
   font-weight: 500;
 }
@@ -1168,7 +1170,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/colors.css
+++ b/colors.css
@@ -1,0 +1,12 @@
+:root {
+  --primary-color: #2c3d4f;
+  --secondary-color: #3e7ab7;
+  --accent-color: #ffbb00;
+  --background-color: #f7f7f7;
+  --text-color: #333333;
+  --muted-color: #e0e0e0;
+  --border-color: #cccccc;
+  --light-color: #ffffff;
+  --dark-text-color: #343434;
+  --shadow: 0 2px 10px rgba(0,0,0,0.06);
+}

--- a/consultas/operativo.css
+++ b/consultas/operativo.css
@@ -1,18 +1,20 @@
+@import url("../colors.css");
+
 * {
   box-sizing: border-box;
   font-family: "Open Sans", sans-serif;
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -33,12 +35,12 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -101,12 +103,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -187,14 +189,14 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .imp-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -282,7 +284,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
-  background: #fff;
+  background: var(--light-color);
   padding: 20px;
   padding-top: 20px;
   border-radius: 12px;
@@ -291,7 +293,7 @@ nav {
 }
 
 .card-grafico {
-  background: #fff;
+  background: var(--light-color);
   padding: 20px 8px 12px 8px;
   border-radius: 12px;
   padding-top: 90px;
@@ -319,10 +321,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
 }
 
 .fitros-consulta input[type="checkbox"],
@@ -391,7 +393,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -417,7 +419,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -457,7 +459,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -465,8 +467,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -478,7 +480,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -527,7 +529,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -547,7 +549,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 .paginacao {
@@ -564,7 +566,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -575,7 +577,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -609,7 +611,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -640,7 +642,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -652,8 +654,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   font-size: 14px;
@@ -663,7 +665,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -676,31 +678,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -819,7 +821,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -830,7 +832,7 @@ th {
 
 .header-table2 th {
   background-color: #e6effa;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 7px 8px;
   height: 26px;
@@ -840,14 +842,14 @@ th {
 }
 
 .header-atv {
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 8px 8px;
   line-height: 1.5;
   text-align: center;
   vertical-align: middle;
   background-color: #e3e6ec;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -855,7 +857,7 @@ th {
 .header-atv span {
   font-size: 14px;
   font-weight: bold;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -872,7 +874,7 @@ th {
 
 .complementar td {
   background-color: #002fff;
-  color: white;
+  color: var(--light-color);
 }
 
 /* ---------- MENU SUSPENSO ---------- */
@@ -885,8 +887,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -896,12 +898,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -921,21 +923,21 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .quantidade {
   background-color: #2b2b2b;
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -945,7 +947,7 @@ body.dark-mode .submenu a {
   color: #ddd;
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .submenu a:hover {
   background-color: #555;
@@ -956,17 +958,17 @@ body.dark-mode .imp-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode th {
   background-color: #3d3d3d;
@@ -992,28 +994,28 @@ body.dark-mode .slider::before {
   box-shadow: inset 8px -3px 0px 0px var(--dark);
 }
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .associar-responsavel button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associar-responsavel button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .guia-eventual td {
   background-color: #ffeebd;
-  color: black;
+  color: var(--dark-text-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1035,7 +1037,7 @@ body.dark-mode .paginacao-direita {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .paginacao-direita button {
@@ -1050,9 +1052,9 @@ body.dark-mode .paginacao button:hover {
   background-color: #555;
 }
 body.dark-mode .paginacao button.ativo {
-  background-color: #007bff;
-  color: white;
-  border-color: #007bff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
+  border-color: var(--secondary-color);
 }
 body.dark-mode .sair {
   text-decoration: none;
@@ -1060,21 +1062,21 @@ body.dark-mode .sair {
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .painel-geral {
@@ -1085,23 +1087,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1111,8 +1113,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1125,7 +1127,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1137,7 +1139,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 340px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1146,8 +1148,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1159,7 +1161,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1179,7 +1181,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   flex-direction: column;
   gap: 10px;
   font-size: 1rem;
-  color: #373737;
+  color: var(--dark-text-color);
 }
 
 .message {
@@ -1193,8 +1195,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   align-self: flex-start;
 }
 .message.user {
-  background: #2776ba;
-  color: white;
+  background: var(--secondary-color);
+  color: var(--light-color);
   align-self: flex-end;
 }
 
@@ -1215,7 +1217,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   outline: none;
 }
 .chat-input-area button {
-  background: #ffc107;
+  background: var(--accent-color);
   border: none;
   padding: 0 16px;
   font-weight: bold;
@@ -1223,7 +1225,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s;
 }
 .chat-input-area button:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/consultas/supervisor.css
+++ b/consultas/supervisor.css
@@ -1,3 +1,5 @@
+@import url("../colors.css");
+
 /* ---------- RESET E BASE ---------- */
 * {
   box-sizing: border-box;
@@ -5,15 +7,15 @@
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -34,12 +36,12 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -102,12 +104,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -188,14 +190,14 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .imp-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -257,7 +259,7 @@ nav {
 .barra-de-progresso-container {
   width: 90%;
   height: 4px;
-  background: #e0e0e0;
+  background: var(--muted-color);
   margin-bottom: 24px;
   overflow: hidden;
   border-radius: 2px;
@@ -266,7 +268,7 @@ nav {
 .barra-de-progresso-bar {
   width: 0;
   height: 100%;
-  background: #2776ba;
+  background: var(--secondary-color);
   transition: width 0s;
 }
 
@@ -299,7 +301,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
-  background: #fff;
+  background: var(--light-color);
   padding: 20px;
   padding-top: 20px;
   border-radius: 12px;
@@ -308,7 +310,7 @@ nav {
 }
 
 .card-grafico {
-  background: #fff;
+  background: var(--light-color);
   padding: 20px 8px 12px 8px;
   border-radius: 12px;
   padding-top: 90px;
@@ -336,10 +338,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
 }
 
 .fitros-consulta input[type="checkbox"],
@@ -394,7 +396,7 @@ nav {
 .associar-responsavel button {
   background-color: #ffb903;
   padding: 8px 16px;
-  color: black;
+  color: var(--dark-text-color);
   border: none;
   font-size: 14px;
   border-radius: 5px;
@@ -403,7 +405,7 @@ nav {
 }
 
 .associar-responsavel button:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .associar-responsavel select {
@@ -428,7 +430,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -454,7 +456,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -494,7 +496,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -502,8 +504,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -515,7 +517,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -564,7 +566,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -584,7 +586,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -602,7 +604,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -613,7 +615,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -647,7 +649,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -678,7 +680,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -690,8 +692,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   font-size: 14px;
@@ -701,7 +703,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -714,31 +716,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -857,7 +859,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -868,7 +870,7 @@ th {
 
 .header-table2 th {
   background-color: #e6effa;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 7px 8px;
   height: 26px;
@@ -878,14 +880,14 @@ th {
 }
 
 .header-atv {
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 8px 8px;
   line-height: 1.5;
   text-align: center;
   vertical-align: middle;
   background-color: #e3e6ec;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -893,7 +895,7 @@ th {
 .header-atv span {
   font-size: 14px;
   font-weight: bold;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -910,7 +912,7 @@ th {
 
 .complementar td {
   background-color: #002fff;
-  color: white;
+  color: var(--light-color);
 }
 
 /* ---------- MENU SUSPENSO ---------- */
@@ -923,8 +925,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -934,12 +936,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -959,21 +961,21 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .quantidade {
   background-color: #2b2b2b;
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -983,7 +985,7 @@ body.dark-mode .submenu a {
   color: #ddd;
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .submenu a:hover {
   background-color: #555;
@@ -994,17 +996,17 @@ body.dark-mode .imp-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .barra-de-progresso-bar {
   background: #ffb800;
@@ -1033,28 +1035,28 @@ body.dark-mode .slider::before {
   box-shadow: inset 8px -3px 0px 0px var(--dark);
 }
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .associar-responsavel button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associar-responsavel button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .guia-eventual td {
   background-color: #ffeebd;
-  color: black;
+  color: var(--dark-text-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1076,7 +1078,7 @@ body.dark-mode .paginacao-direita {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .paginacao-direita button {
@@ -1091,9 +1093,9 @@ body.dark-mode .paginacao button:hover {
   background-color: #555;
 }
 body.dark-mode .paginacao button.ativo {
-  background-color: #007bff;
-  color: white;
-  border-color: #007bff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
+  border-color: var(--secondary-color);
 }
 body.dark-mode .sair {
   text-decoration: none;
@@ -1101,21 +1103,21 @@ body.dark-mode .sair {
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .painel-geral {
@@ -1126,23 +1128,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1152,8 +1154,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1166,7 +1168,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1178,7 +1180,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 340px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1187,8 +1189,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1200,7 +1202,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1220,7 +1222,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   flex-direction: column;
   gap: 10px;
   font-size: 1rem;
-  color: #373737;
+  color: var(--dark-text-color);
 }
 
 .message {
@@ -1234,8 +1236,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   align-self: flex-start;
 }
 .message.user {
-  background: #2776ba;
-  color: white;
+  background: var(--secondary-color);
+  color: var(--light-color);
   align-self: flex-end;
 }
 
@@ -1256,7 +1258,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   outline: none;
 }
 .chat-input-area button {
-  background: #ffc107;
+  background: var(--accent-color);
   border: none;
   padding: 0 16px;
   font-weight: bold;
@@ -1264,7 +1266,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s;
 }
 .chat-input-area button:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/lancamentos/erp.css
+++ b/lancamentos/erp.css
@@ -1,18 +1,20 @@
+@import url("../colors.css");
+
 * {
   box-sizing: border-box;
   font-family: "Open Sans", sans-serif;
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -20,7 +22,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 3px solid #3e7ab7;
+  border-bottom: 3px solid var(--secondary-color);
   padding: 8px 16px;
 }
 .header-left h2 {
@@ -33,21 +35,21 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -129,8 +131,8 @@ nav {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -140,12 +142,12 @@ nav {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -178,8 +180,8 @@ nav {
   gap: 16px;
   align-items: flex-end;
   padding: 20px;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
   margin: 20px;
@@ -198,10 +200,10 @@ nav {
 .filtro-item input,
 .filtro-item select {
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background: #fff;
+  background: var(--light-color);
 }
 
 .filtros-e-grafico {
@@ -219,8 +221,8 @@ nav {
   display: grid;
   grid-template-columns: 1fr;
   gap: 4px;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   padding: 12px 12px 8px 12px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -238,8 +240,8 @@ nav {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   padding: 20px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -295,10 +297,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background: #fff;
+  background: var(--light-color);
 }
 .fitros-consulta input[type="checkbox"],
 .fitros-consulta input[type="radio"] {
@@ -330,8 +332,8 @@ nav {
 }
 
 .consulta {
-  background-color: #ffc107;
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: 600;
   border: none;
   padding: 10px 20px;
@@ -340,7 +342,7 @@ nav {
   transition: background-color 0.2s ease;
 }
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 /* ---------- BUTTONS ---------- */
@@ -369,7 +371,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -383,7 +385,7 @@ nav {
 .campo-pesquisa.ao-lado {
   margin-left: 10px;
   padding: 4px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 14px;
   width: 180px;
@@ -392,12 +394,12 @@ nav {
 
 .campo-pesquisa.ao-lado:focus {
   outline: none;
-  border-color: #ffc107;
+  border-color: var(--accent-color);
   box-shadow: 0 0 0 2px rgba(255, 193, 7, 0.3);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -413,7 +415,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -424,7 +426,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -458,7 +460,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -489,7 +491,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -516,7 +518,7 @@ th {
 }
 
 .lanc-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -524,7 +526,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -540,12 +542,12 @@ body.dark-mode {
 }
 body.dark-mode header {
   background-color: #151f2b;
-  color: white;
-  border-bottom-color: #3e7ab7;
+  color: var(--light-color);
+  border-bottom-color: var(--secondary-color);
 }
 body.dark-mode nav {
   background-color: #2a2a2a;
-  color: white;
+  color: var(--light-color);
   border-bottom: 1px solid #444;
 }
 body.dark-mode .card-filtros,
@@ -570,7 +572,7 @@ body.dark-mode .pagination-select select {
 body.dark-mode .header-table th,
 body.dark-mode th {
   background-color: #414141;
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode td,
 body.dark-mode .tabela-anexos .linha span {
@@ -578,18 +580,18 @@ body.dark-mode .tabela-anexos .linha span {
 }
 body.dark-mode .btn-download-todos,
 body.dark-mode .consulta {
-  background-color: #ffbb00;
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
 }
 body.dark-mode .sair {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .btn-download-todos:hover,
 body.dark-mode .consulta:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .filtros-compactos {
   background-color: #2a2a2a;
@@ -600,20 +602,20 @@ body.dark-mode .submenu {
   border-color: #444;
 }
 body.dark-mode .submenu a {
-  color: #ccc;
+  color: var(--border-color);
 }
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .submenu a:hover {
   background-color: #444;
 }
 body.dark-mode .pagination-nav {
   background: #1f1f1f;
-  color: #ccc;
+  color: var(--border-color);
   box-shadow: none;
 }
 body.dark-mode .pagination-btn {
@@ -623,13 +625,13 @@ body.dark-mode .farol:hover {
   box-shadow: 0 0 8px 2px rgba(255, 255, 255, 0.25);
 }
 body.dark-mode .campo-pesquisa.ao-lado {
-  background-color: #ffffff;
-  color: black;
+  background-color: var(--light-color);
+  color: var(--dark-text-color);
   border: 1px solid #555;
 }
 
 body.dark-mode .campo-pesquisa.ao-lado:focus {
-  border-color: #ffc107;
+  border-color: var(--accent-color);
   box-shadow: 0 0 0 2px rgba(255, 193, 7, 0.3);
   outline: none;
 }
@@ -637,5 +639,5 @@ body.dark-mode .campo-pesquisa.ao-lado:focus {
 body.dark-mode table th,
 body.dark-mode table td {
   border: 1px solid #ddd;
-  color: black;
+  color: var(--dark-text-color);
 }

--- a/lancamentos/style.css
+++ b/lancamentos/style.css
@@ -1,18 +1,20 @@
+@import url("../colors.css");
+
 * {
   box-sizing: border-box;
   font-family: "Open Sans", sans-serif;
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -20,7 +22,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 3px solid #3e7ab7;
+  border-bottom: 3px solid var(--secondary-color);
   padding: 8px 16px;
 }
 .header-left h2 {
@@ -33,21 +35,21 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -129,8 +131,8 @@ nav {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -140,12 +142,12 @@ nav {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -153,8 +155,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   font-size: 14px;
   border-radius: 5px;
@@ -163,7 +165,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -183,8 +185,8 @@ nav {
   gap: 16px;
   align-items: flex-end;
   padding: 20px;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
   margin: 20px;
@@ -204,10 +206,10 @@ nav {
 .filtro-item input,
 .filtro-item select {
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background: #fff;
+  background: var(--light-color);
 }
 
 .filtros-e-grafico {
@@ -225,8 +227,8 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 15px;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   padding: 35px 20px 35px 20px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -244,8 +246,8 @@ nav {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--light-color);
+  border: 1px solid var(--border-color);
   border-radius: 5px;
   padding: 20px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -300,10 +302,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background: #fff;
+  background: var(--light-color);
 }
 .fitros-consulta input[type="checkbox"],
 .fitros-consulta input[type="radio"] {
@@ -335,8 +337,8 @@ nav {
 }
 
 .consulta {
-  background-color: #ffc107;
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: 600;
   border: none;
   padding: 10px 20px;
@@ -345,7 +347,7 @@ nav {
   transition: background-color 0.2s ease;
 }
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 /* Painel expansível */
@@ -369,7 +371,7 @@ nav {
 }
 
 .toggle-filtros.active {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
 }
 
 .toggle-filtros.active .icon {
@@ -459,7 +461,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -473,7 +475,7 @@ nav {
 .campo-pesquisa.ao-lado {
   margin-left: 10px;
   padding: 4px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 14px;
   width: 180px;
@@ -482,12 +484,12 @@ nav {
 
 .campo-pesquisa.ao-lado:focus {
   outline: none;
-  border-color: #ffc107;
+  border-color: var(--accent-color);
   box-shadow: 0 0 0 2px rgba(255, 193, 7, 0.3);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -504,7 +506,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -515,7 +517,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -549,7 +551,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -580,7 +582,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -611,7 +613,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -651,7 +653,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -659,8 +661,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -672,7 +674,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -721,7 +723,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -741,7 +743,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -883,8 +885,8 @@ td.farol-cell {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -897,7 +899,7 @@ td.farol-cell {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -908,7 +910,7 @@ td.farol-cell {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -917,8 +919,8 @@ td.farol-cell {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -930,7 +932,7 @@ td.farol-cell {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -945,12 +947,12 @@ td.farol-cell {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
 .chat-body a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: underline;
   font-weight: 500;
 }
@@ -961,7 +963,7 @@ td.farol-cell {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 /* ---------- TABLES ---------- */
@@ -981,7 +983,7 @@ th {
 }
 
 .lanc-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -990,7 +992,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -1008,13 +1010,13 @@ body.dark-mode {
 
 body.dark-mode header {
   background-color: #151f2b;
-  color: white;
-  border-bottom-color: #3e7ab7;
+  color: var(--light-color);
+  border-bottom-color: var(--secondary-color);
 }
 
 body.dark-mode nav {
   background-color: #2a2a2a;
-  color: white;
+  color: var(--light-color);
   border-bottom: 1px solid #444;
 }
 
@@ -1042,7 +1044,7 @@ body.dark-mode .pagination-select select {
 body.dark-mode .header-table th,
 body.dark-mode th {
   background-color: #414141;
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode td,
@@ -1052,19 +1054,19 @@ body.dark-mode .tabela-anexos .linha span {
 
 body.dark-mode .btn-download-todos,
 body.dark-mode .consulta {
-  background-color: #ffbb00;
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
 }
 body.dark-mode .sair {
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode .btn-download-todos:hover,
 body.dark-mode .consulta:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .filtros-compactos {
   background-color: #2a2a2a;
@@ -1072,12 +1074,12 @@ body.dark-mode .filtros-compactos {
 }
 body.dark-mode .filtro-item input {
   background-color: #1f1f1f;
-  color: white;
+  color: var(--light-color);
   border-color: #555;
 }
 body.dark-mode .filtro-item select {
   background-color: #1f1f1f;
-  color: white;
+  color: var(--light-color);
   border-color: #555;
 }
 body.dark-mode .painel-filtros {
@@ -1090,13 +1092,13 @@ body.dark-mode .submenu {
 }
 
 body.dark-mode .submenu a {
-  color: #ccc;
+  color: var(--border-color);
 }
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode .submenu a:hover {
@@ -1105,7 +1107,7 @@ body.dark-mode .submenu a:hover {
 
 body.dark-mode .pagination-nav {
   background: #1f1f1f;
-  color: #ccc;
+  color: var(--border-color);
   box-shadow: none;
 }
 
@@ -1119,27 +1121,27 @@ body.dark-mode .chat-popup {
 }
 
 body.dark-mode .chat-header {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 body.dark-mode .chat-body a {
   color: #8cbfff;
 }
 body.dark-mode .chat-body p {
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode .farol:hover {
   box-shadow: 0 0 8px 2px rgba(255, 255, 255, 0.25);
 }
 body.dark-mode .campo-pesquisa.ao-lado {
-  background-color: #ffffff;
-  color: black;
+  background-color: var(--light-color);
+  color: var(--dark-text-color);
   border: 1px solid #555;
 }
 
 body.dark-mode .campo-pesquisa.ao-lado:focus {
-  border-color: #ffc107;
+  border-color: var(--accent-color);
   box-shadow: 0 0 0 2px rgba(255, 193, 7, 0.3);
   outline: none;
 }

--- a/login/login.css
+++ b/login/login.css
@@ -1,16 +1,9 @@
-:root {
-  --primary-yellow: #ffc107;
-  --primary-blue: #2776ba;
-  --dark-gray: #373737;
-  --light-gray: #f5f5f5;
-  --white: #fff;
-  --shadow: 0 8px 40px 0 rgba(55, 55, 55, 0.16);
-}
+@import url("../colors.css");
 
 body {
   margin: 0;
   padding: 0;
-  background: #e2e2e2;
+  background: var(--muted-color);
   font-family: "Open Sans", sans-serif;
   min-height: 100vh;
   display: flex;
@@ -33,7 +26,7 @@ body {
   transform: translateY(-50%);
   width: 340px;
   min-height: 350px;
-  background: #ffffff;
+  background: var(--light-color);
   border-radius: 5px;
   z-index: 2;
   box-shadow: var(--shadow);
@@ -53,8 +46,8 @@ body {
 .btn-whatsapp {
   display: inline-flex;
   align-items: center;
-  background: #25d366;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   font-weight: bold;
   border-radius: 8px;
   padding: 5px 12px;
@@ -64,14 +57,14 @@ body {
 }
 
 .btn-whatsapp:hover {
-  background-color: #1aa84e;
+  background-color: var(--secondary-color);
 }
 
 .btn-zendesk {
   display: inline-flex;
   align-items: center;
-  background: #fec107;
-  color: black;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: bold;
   border-radius: 8px;
   padding: 5px 12px;
@@ -82,13 +75,13 @@ body {
   transition: background 0.2s;
 }
 .btn-zendesk:hover {
-  background: #ffd146;
+  background: var(--accent-color);
 }
 
 .btn-saml {
   width: 100%;
-  background: #fec107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: 700;
   border: none;
   padding: 12px 0;
@@ -97,7 +90,7 @@ body {
   cursor: pointer;
   margin-bottom: 20px;
   transition: background 0.2s;
-  box-shadow: 0 2px 10px 0 #0001;
+  box-shadow: 0 2px 10px 0 rgba(0,0,0,0.06);
   letter-spacing: 0.5px;
   display: flex;
   align-items: center;
@@ -107,11 +100,11 @@ body {
 
 .btn-saml a {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .btn-saml:hover {
-  background: #e5b200;
+  background: var(--accent-color);
 }
 
 .divisor {
@@ -119,7 +112,7 @@ body {
   text-align: center;
   margin: 12px 0 18px 0;
   position: relative;
-  color: #535353;
+  color: var(--text-color);
   font-size: 15.68px;
 }
 
@@ -129,7 +122,7 @@ body {
   display: inline-block;
   width: 40%;
   height: 1px;
-  background: #535353;
+  background: var(--text-color);
   position: relative;
   vertical-align: middle;
   margin: 0 8px;
@@ -137,7 +130,7 @@ body {
 
 .login-form h2 {
   margin: 0 0 18px 0;
-  color: #373737;
+  color: var(--dark-text-color);
   font-weight: 700;
   font-size: 19.52px;
   letter-spacing: 1px;
@@ -147,7 +140,7 @@ body {
 .input-group {
   display: flex;
   align-items: center;
-  background: #f5f5f5;
+  background: var(--background-color);
   border: 2px solid transparent;
   border-radius: 9px;
   margin-bottom: 20px;
@@ -155,7 +148,7 @@ body {
 }
 
 .input-group svg {
-  color: #2776ba;
+  color: var(--secondary-color);
   margin-right: 8px;
   font-size: 19.2px;
 }
@@ -167,11 +160,11 @@ body {
   padding: 13px 8px;
   width: 100%;
   font-size: 13.6px;
-  color: #373737;
+  color: var(--dark-text-color);
 }
 .input-group:focus-within {
-  border: 2px solid #2776ba;
-  background: #e6f2fb;
+  border: 2px solid var(--secondary-color);
+  background: var(--background-color);
 }
 
 .esqueceu-senha {
@@ -179,20 +172,20 @@ body {
   align-items: center;
   justify-content: space-between;
   font-size: 15.2px;
-  color: #373737;
+  color: var(--dark-text-color);
   margin-bottom: 18px;
 }
 
 .esqueceu-senha a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
   font-size: 13.6px;
 }
 
 .btn-login {
-  background: #2776ba;
-  color: white;
+  background: var(--secondary-color);
+  color: var(--light-color);
   font-weight: 700;
   border: none;
   padding: 12px 0;
@@ -210,11 +203,11 @@ body {
 
 .btn-login a {
   text-decoration: none;
-  color: white;
+  color: var(--light-color);
 }
 
 .btn-login:hover {
-  background: #185380;
+  background: var(--primary-color);
 }
 
 .welcome-panel {
@@ -223,14 +216,14 @@ body {
   top: 0;
   width: 480px;
   height: 440px;
-  background: #2c3d4f;
+  background: var(--primary-color);
   border-radius: 5px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 1;
-  color: white;
+  color: var(--light-color);
   box-shadow: var(--shadow);
   overflow: hidden;
 }
@@ -240,8 +233,8 @@ body {
   font-weight: 900;
   margin-bottom: 18px;
   margin-left: 40px;
-  color: #ffc107;
-  text-shadow: 1px 2px 8px #0033663c;
+  color: var(--accent-color);
+  text-shadow: 1px 2px 8px rgba(44,61,79,0.24);
   letter-spacing: 1.3px;
 }
 
@@ -255,12 +248,12 @@ body {
 }
 
 .welcome-panel span {
-  color: #ffc107;
+  color: var(--accent-color);
 }
 
 .btn-know {
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   font-weight: bold;
   border: none;
   padding: 12px 42px;
@@ -270,16 +263,16 @@ body {
   cursor: pointer;
   margin-top: 12px;
   transition: background 0.2s;
-  box-shadow: 0 2px 8px 0 #2223;
+  box-shadow: 0 2px 8px 0 rgba(0,0,0,0.2);
 }
 
 .btn-know a {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .btn-know:hover {
-  background: #e5b200;
+  background: var(--accent-color);
 }
 
 @media (max-width: 940px) {
@@ -346,10 +339,10 @@ body {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
-  box-shadow: 0 4px 20px #0002;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.13);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -360,8 +353,8 @@ body {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #d6a100;
-  box-shadow: 0 6px 32px #0003;
+  background: var(--accent-color);
+  box-shadow: 0 6px 32px rgba(0,0,0,0.2);
 }
 
 .chat-popup {
@@ -371,17 +364,17 @@ body {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
-  box-shadow: 0 6px 32px #0003;
+  box-shadow: 0 6px 32px rgba(0,0,0,0.2);
   z-index: 2500;
   overflow: hidden;
   font-family: "Open Sans", "Roboto", Arial, sans-serif;
 }
 
 .chat-header {
-  background: #2c3d4f;
-  color: #fff;
+  background: var(--primary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -393,7 +386,7 @@ body {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -408,7 +401,7 @@ body {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
@@ -423,7 +416,7 @@ body {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/modulos/style.css
+++ b/modulos/style.css
@@ -1,16 +1,9 @@
-:root {
-  --azul: #2776ba;
-  --amarelo: #ffc107;
-  --cinza-claro: #f5f5f5;
-  --cinza-fundo: #e2e2e2;
-  --cinza-escuro: #2c3d4f;
-  --branco: #fff;
-}
+@import url("../colors.css");
 
 body {
   margin: 0;
   font-family: "Open Sans", sans-serif;
-  background: var(--cinza-fundo);
+  background: var(--muted-color);
 }
 
 .pagina-selecao {
@@ -25,8 +18,8 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 8px 16px;
-  background: var(--cinza-escuro);
-  border-bottom: 2px solid #555;
+  background: var(--primary-color);
+  border-bottom: 2px solid var(--text-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
@@ -39,12 +32,12 @@ body {
   align-items: center;
   gap: 12px;
   font-weight: 600;
-  color: white;
+  color: var(--light-color);
 }
 
 .avatar {
-  background: var(--cinza-fundo);
-  color: black;
+  background: var(--muted-color);
+  color: var(--dark-text-color);
   width: 28px;
   height: 28px;
   border-radius: 50%;
@@ -79,7 +72,7 @@ body {
 .titulo-principal {
   font-size: 3.2rem;
   font-weight: 800;
-  color: #111;
+  color: var(--dark-text-color);
   position: relative;
   z-index: 1;
   margin: 0;
@@ -93,14 +86,14 @@ body {
   bottom: 1px;
   width: 100%;
   height: 4px;
-  background: var(--amarelo);
+  background: var(--accent-color);
   border-radius: 10px;
   z-index: 0;
 }
 
 /* Grade de módulos */
 .container-modulos {
-  background: #eeeeee;
+  background: var(--background-color);
   padding: 32px 28px;
   border-radius: 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
@@ -108,7 +101,7 @@ body {
   max-width: 900px;
   max-height: 440px;
   overflow-y: auto;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 
 .lista-modulos {
@@ -121,9 +114,9 @@ body {
   padding: 12px 18px;
   font-size: 1rem;
   font-weight: bold;
-  color: var(--cinza-escuro);
-  background-color: #e0e0e0;
-  border-bottom: 1px solid #eee;
+  color: var(--primary-color);
+  background-color: var(--muted-color);
+  border-bottom: 1px solid var(--background-color);
   transition: background 0.2s ease, padding-left 0.2s ease;
   cursor: pointer;
   border-radius: 6px;
@@ -132,16 +125,16 @@ body {
 
 .lista-modulos a {
   text-decoration: none;
-  color: var(--cinza-escuro);
+  color: var(--primary-color);
 }
 
 .lista-modulos li:nth-child(even) {
-  background-color: var(--cinza-claro);
+  background-color: var(--background-color);
 }
 
 .lista-modulos li:hover {
-  background-color: var(--amarelo);
-  color: #000;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   padding-left: 28px;
 }
 
@@ -150,12 +143,12 @@ body {
 }
 
 .container-modulos::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--background-color);
   border-radius: 10px;
 }
 
 .container-modulos::-webkit-scrollbar-thumb {
-  background-color: var(--amarelo);
+  background-color: var(--accent-color);
   border-radius: 10px;
   border: 2px solid transparent;
   background-clip: content-box;

--- a/obrigacoes/capa-de-processo.css
+++ b/obrigacoes/capa-de-processo.css
@@ -1,3 +1,5 @@
+@import url("../colors.css");
+
 /* ---------- RESET E BASE ---------- */
 * {
   box-sizing: border-box;
@@ -5,15 +7,15 @@
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -34,7 +36,7 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -97,12 +99,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -183,13 +185,13 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .imp-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -262,7 +264,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 8px;
-  background: #fff;
+  background: var(--light-color);
   padding: 16px 16px 10px 16px;
   border-radius: 12px;
   box-shadow: 0 1px 6px rgba(70, 90, 110, 0.07);
@@ -270,7 +272,7 @@ nav {
 }
 
 .card-grafico {
-  background: #ffffff;
+  background: var(--light-color);
   border-radius: 12px;
   padding-top: 40px;
   padding-bottom: 40px;
@@ -287,7 +289,7 @@ nav {
 
 .sair {
   text-decoration: none;
-  color: black;
+  color: var(--dark-text-color);
 }
 
 .fitros-consulta {
@@ -306,10 +308,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 4px 6px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 15px;
-  background-color: white;
+  background-color: var(--light-color);
   margin-bottom: 20px;
 }
 
@@ -365,7 +367,7 @@ nav {
   font-size: 14px;
   margin: 0 0 2px 0;
   padding: 0;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 
 .grupo-associar {
@@ -379,11 +381,11 @@ nav {
 
 .associar-responsavel select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   width: 385px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
   min-width: 140px;
   margin: 0;
 }
@@ -391,7 +393,7 @@ nav {
 .associar-botao {
   padding: 8px 18px;
   background-color: #c9c9c9;
-  color: black;
+  color: var(--dark-text-color);
   border: none;
   border-radius: 5px;
   cursor: pointer;
@@ -431,7 +433,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -457,7 +459,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -497,7 +499,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -505,8 +507,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -518,7 +520,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -567,7 +569,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -587,7 +589,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -605,7 +607,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -616,7 +618,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -651,7 +653,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -682,7 +684,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -694,8 +696,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   margin-bottom: 30px;
@@ -706,7 +708,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -719,31 +721,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -864,7 +866,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
 }
 
@@ -896,8 +898,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -907,12 +909,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -932,21 +934,21 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .quantidade {
   background-color: #2b2b2b;
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -969,17 +971,17 @@ body.dark-mode .imp-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode th {
   background-color: #3d3d3d;
@@ -1005,22 +1007,22 @@ body.dark-mode .slider::before {
   box-shadow: inset 8px -3px 0px 0px var(--dark);
 }
 body.dark-mode .associacao button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associacao button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1038,33 +1040,33 @@ body.dark-mode .container {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .painel-geral {
@@ -1075,23 +1077,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1101,8 +1103,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1115,7 +1117,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1126,7 +1128,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1135,8 +1137,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1148,7 +1150,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1163,12 +1165,12 @@ body.dark-mode .fitros-consulta input::placeholder {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
 .chat-body a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: underline;
   font-weight: 500;
 }
@@ -1179,7 +1181,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/obrigacoes/operativo.css
+++ b/obrigacoes/operativo.css
@@ -1,3 +1,5 @@
+@import url("../colors.css");
+
 /* ---------- RESET E BASE ---------- */
 * {
   box-sizing: border-box;
@@ -5,15 +7,15 @@
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -34,12 +36,12 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -102,12 +104,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -188,14 +190,14 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .obr-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -283,7 +285,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
-  background: #fff;
+  background: var(--light-color);
   padding: 20px;
   padding-top: 20px;
   border-radius: 12px;
@@ -292,7 +294,7 @@ nav {
 }
 
 .card-grafico {
-  background: #fff;
+  background: var(--light-color);
   padding: 20px 8px 12px 8px;
   border-radius: 12px;
   padding-top: 90px;
@@ -320,10 +322,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
 }
 
 .fitros-consulta input[type="checkbox"],
@@ -392,7 +394,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -418,7 +420,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -458,7 +460,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -466,8 +468,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -479,7 +481,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -528,7 +530,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -548,7 +550,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -566,7 +568,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -577,7 +579,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -612,7 +614,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -643,7 +645,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -655,8 +657,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   font-size: 14px;
@@ -666,7 +668,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -679,31 +681,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -823,7 +825,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -834,7 +836,7 @@ th {
 
 .header-table2 th {
   background-color: #e6effa;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 7px 8px;
   height: 26px;
@@ -844,14 +846,14 @@ th {
 }
 
 .header-atv {
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 8px 8px;
   line-height: 1.5;
   text-align: center;
   vertical-align: middle;
   background-color: #e3e6ec;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -859,7 +861,7 @@ th {
 .header-atv span {
   font-size: 14px;
   font-weight: bold;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -876,7 +878,7 @@ th {
 
 .complementar td {
   background-color: #002fff;
-  color: white;
+  color: var(--light-color);
 }
 
 /* ---------- MENU SUSPENSO ---------- */
@@ -889,8 +891,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -900,12 +902,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -925,18 +927,18 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -946,7 +948,7 @@ body.dark-mode .submenu a {
   color: #ddd;
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .submenu a:hover {
   background-color: #555;
@@ -957,17 +959,17 @@ body.dark-mode .obr-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode th {
   background-color: #3d3d3d;
@@ -993,28 +995,28 @@ body.dark-mode .slider::before {
   box-shadow: inset 8px -3px 0px 0px var(--dark);
 }
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .associar-responsavel button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associar-responsavel button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .guia-eventual td {
   background-color: #ffeebd;
-  color: black;
+  color: var(--dark-text-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1036,7 +1038,7 @@ body.dark-mode .paginacao-direita {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .paginacao-direita button {
@@ -1051,9 +1053,9 @@ body.dark-mode .paginacao button:hover {
   background-color: #555;
 }
 body.dark-mode .paginacao button.ativo {
-  background-color: #007bff;
-  color: white;
-  border-color: #007bff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
+  border-color: var(--secondary-color);
 }
 body.dark-mode .sair {
   text-decoration: none;
@@ -1061,21 +1063,21 @@ body.dark-mode .sair {
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .quantidade {
   background-color: #232323;
@@ -1089,23 +1091,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1115,8 +1117,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1129,7 +1131,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1140,7 +1142,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1149,8 +1151,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1162,7 +1164,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1177,12 +1179,12 @@ body.dark-mode .fitros-consulta input::placeholder {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
 .chat-body a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: underline;
   font-weight: 500;
 }
@@ -1193,7 +1195,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {

--- a/obrigacoes/supervisor.css
+++ b/obrigacoes/supervisor.css
@@ -1,3 +1,5 @@
+@import url("../colors.css");
+
 /* ---------- RESET E BASE ---------- */
 * {
   box-sizing: border-box;
@@ -5,15 +7,15 @@
 }
 body {
   margin: 0;
-  background-color: #f7f7f7;
-  color: #333;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-family: "Open Sans", sans-serif;
 }
 
 /* ---------- HEADER ---------- */
 header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
   padding: 12px 24px;
   font-size: 20px;
 }
@@ -34,12 +36,12 @@ header {
 }
 .mainmenu {
   text-decoration: none;
-  color: #ffffff;
+  color: var(--light-color);
 }
 
 .sair {
   text-decoration: none;
-  color: #343434;
+  color: var(--dark-text-color);
 }
 
 /* ---------- FAROL DE STATUS ---------- */
@@ -102,12 +104,12 @@ header {
 /* ---------- Navegação ---------- */
 
 nav {
-  background-color: #e0e0e0;
+  background-color: var(--muted-color);
   padding: 10px 20px;
   display: flex;
   gap: 20px;
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   font-size: 18px;
 }
@@ -188,14 +190,14 @@ nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .obr-info {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .quantidade {
-  background-color: white;
+  background-color: var(--light-color);
   padding-top: 20px;
   padding-right: 20px;
   padding-left: 20px;
@@ -257,7 +259,7 @@ nav {
 .barra-de-progresso-container {
   width: 90%;
   height: 4px;
-  background: #e0e0e0;
+  background: var(--muted-color);
   margin-bottom: 24px;
   overflow: hidden;
   border-radius: 2px;
@@ -266,7 +268,7 @@ nav {
 .barra-de-progresso-bar {
   width: 0;
   height: 100%;
-  background: #2776ba;
+  background: var(--secondary-color);
   transition: width 0s;
 }
 
@@ -288,7 +290,7 @@ nav {
 .associar-responsavel button {
   background-color: #ffb903;
   padding: 8px 16px;
-  color: black;
+  color: var(--dark-text-color);
   border: none;
   font-size: 14px;
   border-radius: 5px;
@@ -315,7 +317,7 @@ nav {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
-  background: #fff;
+  background: var(--light-color);
   padding: 20px;
   padding-top: 20px;
   border-radius: 12px;
@@ -324,7 +326,7 @@ nav {
 }
 
 .card-grafico {
-  background: #fff;
+  background: var(--light-color);
   padding: 20px 8px 12px 8px;
   border-radius: 12px;
   padding-top: 90px;
@@ -352,10 +354,10 @@ nav {
 .fitros-consulta input,
 .fitros-consulta select {
   padding: 6px 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
-  background-color: white;
+  background-color: var(--light-color);
 }
 
 .fitros-consulta input[type="checkbox"],
@@ -424,7 +426,7 @@ nav {
 }
 
 .baixar-anexos {
-  color: #007bff;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: 500;
 }
@@ -450,7 +452,7 @@ nav {
 }
 
 .modal-conteudo {
-  background-color: #fff;
+  background-color: var(--light-color);
   margin: 5% auto;
   padding: 24px 28px;
   border-radius: 12px;
@@ -490,7 +492,7 @@ nav {
 .modal-conteudo h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   border-bottom: 1px solid #eee;
   padding-bottom: 8px;
 }
@@ -498,8 +500,8 @@ nav {
 /* Botão principal */
 .btn-download-todos {
   display: inline-block;
-  background-color: #2776ba;
-  color: #fff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
   padding: 10px 20px;
   font-weight: 600;
   font-size: 14px;
@@ -511,7 +513,7 @@ nav {
 }
 
 .btn-download-todos:hover {
-  background-color: #1d5e98;
+  background-color: var(--secondary-color);
 }
 
 /* Tabela com anexos */
@@ -560,7 +562,7 @@ nav {
 }
 
 .tabela-anexos a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: none;
   word-break: break-word;
 }
@@ -580,7 +582,7 @@ nav {
   width: 6px;
 }
 .tabela-anexos::-webkit-scrollbar-thumb {
-  background-color: #fabc00;
+  background-color: var(--accent-color);
   border-radius: 4px;
 }
 
@@ -598,7 +600,7 @@ nav {
   width: 50px;
   padding: 4px 6px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
 }
 .paginacao button {
   padding: 4px 10px;
@@ -609,7 +611,7 @@ nav {
   transition: background 0.2s;
 }
 .paginacao button:hover {
-  background: #e0e0e0;
+  background: var(--muted-color);
 }
 
 .linha-total-paginacao {
@@ -644,7 +646,7 @@ nav {
   padding: 3px 8px;
   font-size: 14px;
   background: #f9fafc;
-  color: #333;
+  color: var(--text-color);
   margin: 0 4px;
 }
 
@@ -675,7 +677,7 @@ nav {
   border-radius: 4px;
   padding: 2px 2px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-color);
   background: #f9fafc;
 }
 
@@ -687,8 +689,8 @@ nav {
 
 .consulta {
   padding: 10px 16px;
-  background-color: rgb(255, 187, 0);
-  color: black;
+  background-color: var(--accent-color);
+  color: var(--dark-text-color);
   border: none;
   margin-top: 5px;
   font-size: 14px;
@@ -698,7 +700,7 @@ nav {
 }
 
 .consulta:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
 }
 
 .container-button {
@@ -711,31 +713,31 @@ nav {
   flex-wrap: wrap;
 }
 .archives {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #e0a800;
+  color: var(--dark-text-color);
+  border: 3px solid var(--secondary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .archives:hover {
-  background-color: #e0a800;
+  background-color: var(--secondary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 .eventual {
-  background-color: white;
+  background-color: var(--light-color);
   padding: 8px 16px;
-  color: black;
-  border: 3px solid #2c3d4f;
+  color: var(--dark-text-color);
+  border: 3px solid var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.267);
   border-radius: 8px;
   cursor: pointer;
 }
 .eventual:hover {
-  background-color: #2c3d4f;
+  background-color: var(--primary-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-  color: white;
+  color: var(--light-color);
 }
 .carregar-arquivos {
   display: flex;
@@ -855,7 +857,7 @@ th {
 .header-table th {
   background-color: #7c7c7e52;
   border: 1px solid #484848;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 14px;
   padding: 6px 6px;
   height: 28px;
@@ -866,7 +868,7 @@ th {
 
 .header-table2 th {
   background-color: #e6effa;
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 7px 8px;
   height: 26px;
@@ -876,14 +878,14 @@ th {
 }
 
 .header-atv {
-  color: black;
+  color: var(--dark-text-color);
   font-size: 13px;
   padding: 8px 8px;
   line-height: 1.5;
   text-align: center;
   vertical-align: middle;
   background-color: #e3e6ec;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -891,7 +893,7 @@ th {
 .header-atv span {
   font-size: 14px;
   font-weight: bold;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -908,7 +910,7 @@ th {
 
 .complementar td {
   background-color: #002fff;
-  color: white;
+  color: var(--light-color);
 }
 
 /* ---------- MENU SUSPENSO ---------- */
@@ -921,8 +923,8 @@ th {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
-  border: 1px solid #ccc;
+  background-color: var(--light-color);
+  border: 1px solid var(--border-color);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   padding: 10px 0;
@@ -932,12 +934,12 @@ th {
 .submenu a {
   display: block;
   padding: 8px 20px;
-  color: #333;
+  color: var(--text-color);
   text-decoration: none;
-  white-space: nowrap;
+  var(--light-color)-space: nowrap;
 }
 .submenu a:hover {
-  background-color: #f2f2f2;
+  background-color: var(--muted-color);
 }
 .menu-item:hover .submenu {
   display: block;
@@ -957,18 +959,18 @@ th {
 /* ---------- DARK MODE ---------- */
 body.dark-mode {
   background-color: #252525;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode header {
-  background-color: #2c3d4f;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--light-color);
 }
 body.dark-mode nav {
-  background-color: #333;
+  background-color: var(--text-color);
   border-bottom: 1px solid #555;
 }
 body.dark-mode .mainmenu {
-  color: #fff;
+  color: var(--light-color);
 }
 body.dark-mode .submenu {
   background-color: #444;
@@ -978,7 +980,7 @@ body.dark-mode .submenu a {
   color: #ddd;
 }
 body.dark-mode .titulo-grafico {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .submenu a:hover {
   background-color: #555;
@@ -992,17 +994,17 @@ body.dark-mode .obr-info {
   box-shadow: none;
 }
 body.dark-mode .form-header h3 {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #666;
 }
 body.dark-mode table {
   background-color: #2c2c2c;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode th {
   background-color: #3d3d3d;
@@ -1032,28 +1034,28 @@ body.dark-mode .quantidade {
 }
 
 body.dark-mode .pagination-select {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .pagination-total {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .associar-responsavel button:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .associar-responsavel button:hover {
   background-color: #c59101;
 }
 body.dark-mode .archives:hover {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 body.dark-mode .eventual:hover {
-  color: white;
+  color: var(--light-color);
 }
 body.dark-mode .guia-eventual td {
   background-color: #ffeebd;
-  color: black;
+  color: var(--dark-text-color);
 }
 body.dark-mode .checkbox:checked ~ .slider {
   background-color: var(--dark);
@@ -1075,7 +1077,7 @@ body.dark-mode .paginacao-direita {
 body.dark-mode .select-registros,
 body.dark-mode .input-pagina {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .paginacao-direita button {
@@ -1090,9 +1092,9 @@ body.dark-mode .paginacao button:hover {
   background-color: #555;
 }
 body.dark-mode .paginacao button.ativo {
-  background-color: #007bff;
-  color: white;
-  border-color: #007bff;
+  background-color: var(--secondary-color);
+  color: var(--light-color);
+  border-color: var(--secondary-color);
 }
 body.dark-mode .sair {
   text-decoration: none;
@@ -1100,21 +1102,21 @@ body.dark-mode .sair {
 }
 
 body.dark-mode .form-header {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .form-header h3 {
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .consulta,
 body.dark-mode .btn-consulta-flutuante {
-  background-color: #fcb900;
+  background-color: var(--accent-color);
   color: #242c35;
 }
 body.dark-mode .consulta:hover,
 body.dark-mode .btn-consulta-flutuante:hover {
   background-color: #c59101;
-  color: #fff;
+  color: var(--light-color);
 }
 
 body.dark-mode .painel-geral {
@@ -1125,23 +1127,23 @@ body.dark-mode .card-grafico {
   background-color: #232323;
   border-color: #444a53;
   box-shadow: none;
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input,
 body.dark-mode .fitros-consulta select {
   background-color: #3a3a3a;
-  color: #fff;
+  color: var(--light-color);
   border: 1px solid #555;
 }
 body.dark-mode .fitros-consulta label {
-  color: #e0e0e0;
+  color: var(--muted-color);
 }
 body.dark-mode .fitros-consulta input[type="checkbox"],
 body.dark-mode .fitros-consulta input[type="radio"] {
-  accent-color: #fcb900;
+  accent-color: var(--accent-color);
 }
 body.dark-mode .fitros-consulta input::placeholder {
-  color: #cccccc;
+  color: var(--border-color);
   opacity: 1;
 }
 
@@ -1151,8 +1153,8 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 40px;
   width: 56px;
   height: 56px;
-  background: #ffc107;
-  color: #373737;
+  background: var(--accent-color);
+  color: var(--dark-text-color);
   border-radius: 50%;
   box-shadow: 0 4px 20px #0002;
   display: flex;
@@ -1165,7 +1167,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   transition: background 0.2s, box-shadow 0.2s;
 }
 .helpFab:hover {
-  background: #ffdb5c;
+  background: var(--accent-color);
   box-shadow: 0 6px 32px #0003;
 }
 
@@ -1176,7 +1178,7 @@ body.dark-mode .fitros-consulta input::placeholder {
   right: 48px;
   width: 320px;
   max-width: 95vw;
-  background: #fff;
+  background: var(--light-color);
   border-radius: 14px;
   box-shadow: 0 6px 32px #0003;
   z-index: 2500;
@@ -1185,8 +1187,8 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-header {
-  background: #2776ba;
-  color: #fff;
+  background: var(--secondary-color);
+  color: var(--light-color);
   padding: 13px 16px;
   font-weight: bold;
   display: flex;
@@ -1198,7 +1200,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 .close-chat {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--light-color);
   font-size: 20.8px;
   cursor: pointer;
   padding: 0 4px;
@@ -1213,12 +1215,12 @@ body.dark-mode .fitros-consulta input::placeholder {
 
 .chat-body {
   padding: 18px 16px 16px 16px;
-  color: #373737;
+  color: var(--dark-text-color);
   font-size: 16.16px;
 }
 
 .chat-body a {
-  color: #2776ba;
+  color: var(--secondary-color);
   text-decoration: underline;
   font-weight: 500;
 }
@@ -1229,7 +1231,7 @@ body.dark-mode .fitros-consulta input::placeholder {
 }
 
 .chat-body strong {
-  color: #c59400;
+  color: var(--accent-color);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Introduce `colors.css` with a shared set of theme variables
- Refactor module selection, login, and remaining pages to import the palette and use variables
- Add missing `--shadow` variable for consistent box shadows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a29c1ed5c8330a90e558932863d2b